### PR TITLE
Update otherFavorites.js

### DIFF
--- a/routes/otherFavorites.js
+++ b/routes/otherFavorites.js
@@ -14,4 +14,4 @@ router.get('/showOtherUserFavorites', function(req, res, next) {
 	res.redirect('/otherFavorites');
 });
 
-module.export = router;
+module.exports = router;


### PR DESCRIPTION
Missing s on module.exports! That's where the error is from. app.js is able to require otherFavorites.js now.
